### PR TITLE
Fix #27: event ring buffer holds HMSLEvent structs with loc info

### DIFF
--- a/native/osx/src/HMSLView.m
+++ b/native/osx/src/HMSLView.m
@@ -11,18 +11,18 @@
 @implementation HMSLView
 
 - (void)mouseDown:(NSEvent *)event {
-  gHMSLContext.mouseEvent = [self flipEventCoordinates:event];
-  hmslAddEvent(EV_MOUSE_DOWN);
+  HMSLPoint loc = [self flipEventCoordinates:event];
+  hmslAddMouseEvent(EV_MOUSE_DOWN, loc);
 }
 
 - (void)mouseUp:(NSEvent *)event {
-  gHMSLContext.mouseEvent = [self flipEventCoordinates:event];
-  hmslAddEvent(EV_MOUSE_UP);
+  HMSLPoint loc = [self flipEventCoordinates:event];
+  hmslAddMouseEvent(EV_MOUSE_UP, loc);
 }
 
 - (void)mouseDragged:(NSEvent *)event {
-  gHMSLContext.mouseEvent = [self flipEventCoordinates:event];
-  hmslAddEvent(EV_MOUSE_MOVE);
+  HMSLPoint loc = [self flipEventCoordinates:event];
+  hmslAddMouseEvent(EV_MOUSE_MOVE, loc);
 }
 
 - (void)keyDown:(NSEvent *)event {

--- a/native/osx/src/hmsl.h
+++ b/native/osx/src/hmsl.h
@@ -70,11 +70,27 @@ enum HMSLColor {
   YELLOW
 };
 
+enum HMSLEventID {
+  EV_NULL,
+  EV_MOUSE_DOWN,
+  EV_MOUSE_UP,
+  EV_MOUSE_MOVE,
+  EV_MENU_PICK,
+  EV_CLOSE_WINDOW,
+  EV_REFRESH,
+  EV_KEY
+};
+
+typedef struct HMSLEvent {
+  enum HMSLEventID id;
+  HMSLPoint loc;
+} HMSLEvent;
+
 typedef struct HMSLContext {
   HMSLPoint currentPoint;
   HMSLPoint mouseEvent;
   enum HMSLColor color;
-  enum HMSLEventID *events;
+  HMSLEvent *events;
   uint32_t events_read_loc;
   uint32_t events_write_loc;
 } hmslContext;
@@ -87,16 +103,6 @@ typedef struct HMSLWindow {
   long title;
 } hmslWindow;
 
-enum HMSLEventID {
-  EV_NULL,
-  EV_MOUSE_DOWN,
-  EV_MOUSE_UP,
-  EV_MOUSE_MOVE,
-  EV_MENU_PICK,
-  EV_CLOSE_WINDOW,
-  EV_REFRESH,
-  EV_KEY
-} anHMSLEventID;
 
 /*
  * global variables
@@ -132,8 +138,8 @@ int32_t hostGetEvent( int32_t timeout );
  * communication with the obj-c layer
  */
 
-void hmslAddEvent( enum HMSLEventID );
-enum HMSLEventID hmslGetEvent( void );
+void hmslAddEvent( enum HMSLEventID event_type );
+void hmslAddMouseEvent( enum HMSLEventID event_type, HMSLPoint loc );
 char* nullTermString( const char*, int32_t );
 void hmslDrawLine( HMSLPoint start, HMSLPoint end );
 void hmslSetCurrentWindow( uint32_t );

--- a/native/osx/src/hmsl_cocoa_glue.m
+++ b/native/osx/src/hmsl_cocoa_glue.m
@@ -144,20 +144,27 @@ char* nullTermString( const char* string, int32_t size ) {
   return out;
 }
 
+int32_t hmslAvailableEventFIFO() {
+  return EVENT_BUFFER_SIZE - ((gHMSLContext.events_write_loc - gHMSLContext.events_read_loc) & ((2 * EVENT_BUFFER_SIZE) - 1));
+}
 
 void hmslAddEvent( enum HMSLEventID event_type ) {
-  HMSLEvent event;
-  event.id = event_type;
-  gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event;
-  gHMSLContext.events_write_loc += 1;
+  if (hmslAvailableEventFIFO() > 0) {
+    HMSLEvent event;
+    event.id = event_type;
+    gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event;
+    gHMSLContext.events_write_loc += 1;
+  }
   return;
 }
 
 void hmslAddMouseEvent( enum HMSLEventID event_type, HMSLPoint loc ) {
-  HMSLEvent event;
-  event.id = event_type;
-  event.loc = loc;
-  gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event;
-  gHMSLContext.events_write_loc += 1;
+  if (hmslAvailableEventFIFO() > 0) {
+    HMSLEvent event;
+    event.id = event_type;
+    event.loc = loc;
+    gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event;
+    gHMSLContext.events_write_loc += 1;
+  }
   return;
 }

--- a/native/osx/src/hmsl_cocoa_glue.m
+++ b/native/osx/src/hmsl_cocoa_glue.m
@@ -146,13 +146,18 @@ char* nullTermString( const char* string, int32_t size ) {
 
 
 void hmslAddEvent( enum HMSLEventID event_type ) {
-  gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event_type;
+  HMSLEvent event;
+  event.id = event_type;
+  gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event;
   gHMSLContext.events_write_loc += 1;
   return;
 }
 
-enum HMSLEventID hmslGetEvent( void ) {
-  enum HMSLEventID val = gHMSLContext.events[gHMSLContext.events_read_loc & EVENT_BUFFER_MASK];
-  gHMSLContext.events_read_loc += 1;
-  return val;
+void hmslAddMouseEvent( enum HMSLEventID event_type, HMSLPoint loc ) {
+  HMSLEvent event;
+  event.id = event_type;
+  event.loc = loc;
+  gHMSLContext.events[gHMSLContext.events_write_loc & EVENT_BUFFER_MASK] = event;
+  gHMSLContext.events_write_loc += 1;
+  return;
 }

--- a/native/osx/src/hmsl_gui.c
+++ b/native/osx/src/hmsl_gui.c
@@ -10,7 +10,7 @@
 #import "pf_all.h"
 
 int32_t hostInit( void ) {
-  gHMSLContext.events = malloc(sizeof(enum HMSLEventID) * EVENT_BUFFER_SIZE);
+  gHMSLContext.events = malloc(sizeof(HMSLEvent) * EVENT_BUFFER_SIZE);
   gHMSLContext.events_read_loc = 0;
   gHMSLContext.events_write_loc = 0;
   return -1;
@@ -175,8 +175,20 @@ void hostGetMouse( uint32_t x, uint32_t y) {
  */
 int32_t hostGetEvent( int32_t timeout ) {
   if (gHMSLContext.events_read_loc < gHMSLContext.events_write_loc) {
-    // Case statement should set global variables for mouseEvent, keyPress, etc.
-    return hmslGetEvent();
+    HMSLEvent event = gHMSLContext.events[gHMSLContext.events_read_loc & EVENT_BUFFER_MASK];
+    gHMSLContext.events_read_loc += 1;
+    switch (event.id) {
+      case EV_MOUSE_DOWN:
+      case EV_MOUSE_MOVE:
+      case EV_MOUSE_UP:
+        gHMSLContext.mouseEvent.x = event.loc.x;
+        gHMSLContext.mouseEvent.y = event.loc.y;
+        break;
+      default:
+        break;
+    }
+    
+    return event.id;
   } else {
     return EV_NULL;
   }


### PR DESCRIPTION
This has a little bit of extra data so that mouse event coordinates don't get lost in the mad clicking.

Slightly larger on the stack for events, but I think that modern computers can perhaps handle passing around 3 ints instead of 1.