### PR TITLE
Title bar now displays properly

### DIFF
--- a/native/osx/hmsl/Info.plist
+++ b/native/osx/hmsl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.4</string>
+	<string>0.3.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/native/osx/src/HMSLWindow.h
+++ b/native/osx/src/HMSLWindow.h
@@ -23,6 +23,8 @@
 - (void) drawLineFrom: (HMSLPoint) start to: (HMSLPoint) end;
 - (void) drawText: (NSString*) text atPoint: (NSPoint) point;
 - (void) flushCurrentContext;
+- (void) hmslDrawingMode: (int32_t) mode;
+- (void) hmslDrawingColor: (const double*) color;
 - (void) hmslBackgroundColor: (const double*) color;
 
 @end

--- a/native/osx/src/HMSLWindowDelegate.h
+++ b/native/osx/src/HMSLWindowDelegate.h
@@ -7,6 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "HMSLWindow.h"
 
 @interface HMSLWindowDelegate : NSObject<NSWindowDelegate>
 

--- a/native/osx/src/HMSLWindowDelegate.m
+++ b/native/osx/src/HMSLWindowDelegate.m
@@ -13,6 +13,7 @@
 
 -(void)windowWillClose:(NSNotification *)notification {
   hmslAddEvent(EV_CLOSE_WINDOW);
+  HMSLWindow *window = (HMSLWindow*)[notification object];
 }
 
 @end

--- a/native/osx/src/hmsl.h
+++ b/native/osx/src/hmsl.h
@@ -108,9 +108,7 @@ typedef struct HMSLWindow {
  * global variables
  */
 
-
 hmslContext gHMSLContext;
-CGContextRef drawingContext;
 
 /*
  * hmsl_gui.m
@@ -148,9 +146,10 @@ uint32_t hmslOpenWindow( const char* title, short x, short y, short w, short h )
 void hmslFillRectangle( HMSLRect rect );
 void hmslDrawText( const char*, int32_t, HMSLPoint );
 uint32_t hmslGetTextLength( const char*, int32_t );
-void hmslSetDrawingColor( CGContextRef, const double* );
+void hmslSetDrawingColor( const double* );
 void hmslSetBackgroundColor( const double* );
 void hmslSetTextSize( int32_t );
+void hmslSetDrawingMode( int32_t );
 
 /* 
  * hmsl_midi.m

--- a/native/osx/src/hmsl_cocoa_glue.m
+++ b/native/osx/src/hmsl_cocoa_glue.m
@@ -19,10 +19,8 @@ HMSLWindow *mainWindow;
 void hmslSetBackgroundColor( const double* color ) {
   if (mainWindow != NULL) {
     [mainWindow hmslBackgroundColor:color];
-    @autoreleasepool {
-      NSColor *bgcolor = [NSColor colorWithRed:color[0] green:color[1] blue:color[2] alpha:color[3]];
-      [APP.fontAttributes setObject:bgcolor forKey:NSBackgroundColorAttributeName];
-    }
+    NSColor *bgcolor = [NSColor colorWithRed:color[0] green:color[1] blue:color[2] alpha:color[3]];
+    [APP.fontAttributes setObject:bgcolor forKey:NSBackgroundColorAttributeName];
   }
 }
 
@@ -63,31 +61,18 @@ uint32_t hmslOpenWindow(const char* title, short x, short y, short w, short h) {
   HMSLWindow* hmslWindow = [HMSLWindow hmslWindowWithTitle:windowTitle frame:frame];
   [hmslWindow hmslBackgroundColor:hmslColors[0]];
   mainWindow = hmslWindow;
-  
-  NSGraphicsContext *currentContext = [NSGraphicsContext graphicsContextWithWindow:hmslWindow];
-  currentContext.shouldAntialias = NO;
-  
-  if (currentContext != nil) {
-    NSGraphicsContext.currentContext = currentContext;
-    hmslWindow.graphicsContext = currentContext;
-    drawingContext = currentContext.graphicsPort;
-  } else {
-    NSLog(@"Unable to initialize context");
-  }
-  
   return (uint32_t)hmslWindow.windowNumber;
 }
 
-void hmslSetDrawingColor( CGContextRef context, const double* rgba ) {
-
-  @autoreleasepool {
-    NSColor *newColor = [NSColor colorWithRed:rgba[0] green:rgba[1] blue:rgba[2] alpha:rgba[3]];
-    [newColor set];
-    [APP.fontAttributes setObject:newColor forKey:NSForegroundColorAttributeName];
-    CGContextSetRGBFillColor(context, rgba[0], rgba[1], rgba[2], rgba[3]);
-    CGContextSetRGBStrokeColor(context, rgba[0], rgba[1], rgba[2], rgba[3]);
+void hmslSetDrawingColor( const double* rgba ) {
+  if (mainWindow != NULL) {
+    [mainWindow hmslDrawingColor: rgba];
   }
-  
+  return;
+}
+
+void hmslSetDrawingMode( int32_t mode ) {
+  [mainWindow hmslDrawingMode: mode];
   return;
 }
 
@@ -121,16 +106,18 @@ uint32_t hmslGetTextLength( const char* string, int32_t size ) {
 void hmslDrawText( const char* string, int32_t size, HMSLPoint loc ) {
   
   @autoreleasepool {
-    char* nullTerm = nullTermString(string, size);
-    NSString *text = [NSString stringWithCString: nullTerm encoding:NSASCIIStringEncoding];
-    
-    NSPoint point;
-    point.x = loc.x;
-    point.y = ((HMSLView*)mainWindow.contentView).frame.size.height - loc.y - 3;
-    
-    [mainWindow drawText:text atPoint:point];
-    
-    free(nullTerm);
+    if (mainWindow != NULL) {
+      char* nullTerm = nullTermString(string, size);
+      NSString *text = [NSString stringWithCString: nullTerm encoding:NSASCIIStringEncoding];
+      
+      NSPoint point;
+      point.x = loc.x;
+      point.y = ((HMSLView*)mainWindow.contentView).frame.size.height - loc.y - 3;
+      
+      [mainWindow drawText:text atPoint:point];
+      
+      free(nullTerm);
+    }
   }
   
   return;

--- a/native/osx/src/hmsl_gui.c
+++ b/native/osx/src/hmsl_gui.c
@@ -62,7 +62,6 @@ void hostMoveTo( int32_t x, int32_t y ) {
 void hostDrawText( uint32_t address, int32_t count ) {
   hmslDrawText( (char*)address, count, gHMSLContext.currentPoint );
   gHMSLContext.currentPoint.x += hmslGetTextLength( (char*)address, count);
-  CGContextSynchronize(drawingContext);
   return;
 }
 
@@ -99,9 +98,7 @@ void hostFillRectangle( int32_t x1, int32_t y1, int32_t x2, int32_t y2 ) {
  * color - index of color to use, defined as constants in hmsl.h
  */
 void hostSetColor( int32_t color ) {
-  if (drawingContext != nil) {
-      hmslSetDrawingColor(drawingContext, hmslColors[color & HMSL_COLORS_MASK]);
-  }
+  hmslSetDrawingColor(hmslColors[color & HMSL_COLORS_MASK]);
   return;
 }
 
@@ -112,7 +109,6 @@ void hostSetColor( int32_t color ) {
  */
 void hostSetBackgroundColor( int32_t color ) {
   hmslSetBackgroundColor(hmslColors[color & HMSL_COLORS_MASK]);
-  CGContextSynchronize(drawingContext);
   return;
 }
 
@@ -122,14 +118,7 @@ void hostSetBackgroundColor( int32_t color ) {
  * mode - 0 for normal (overwrite); 1 for XOR.
  */
 void hostSetDrawingMode( int32_t mode ) {
-  switch (mode) {
-    case 0:
-      CGContextSetBlendMode(drawingContext, kCGBlendModeNormal);
-      break;
-    case 1:
-      CGContextSetBlendMode(drawingContext, kCGBlendModeExclusion);
-      break;
-  }
+  hmslSetDrawingMode(mode);
   return;
 }
 


### PR DESCRIPTION
Although this properly displays the title bar on OSX 10.10+, it throws a warning every time a window is opening. That's another issue.

Additionally, finished cleaning up the code to separate things into window-specific drawing contexts.